### PR TITLE
feat: 模型多选弹窗、密钥卡片优化、Discord 服务器拉黑

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,6 @@ DISCORD_CLIENT_SECRET=
 DISCORD_REDIRECT_URI=http://localhost:8787/api/auth/discord/callback
 DISCORD_ALLOWED_GUILD_ID=
 DISCORD_ALLOWED_ROLE_ID=
+# Comma-separated Discord server (guild) IDs to blacklist. Users who belong to any
+# of these servers are denied registration/login (requests the "guilds" scope).
+DISCORD_BLOCKED_GUILD_IDS=

--- a/cmd/capi/main.go
+++ b/cmd/capi/main.go
@@ -121,26 +121,28 @@ type Account struct {
 }
 
 type DiscordSettings struct {
-	Managed         bool   `json:"managed,omitempty"`
-	Enabled         bool   `json:"enabled"`
-	ClientID        string `json:"clientId,omitempty"`
-	ClientSecret    string `json:"clientSecret,omitempty"`
-	RedirectURI     string `json:"redirectUri,omitempty"`
-	AllowedGuildID  string `json:"allowedGuildId,omitempty"`
-	AllowedRoleID   string `json:"allowedRoleId,omitempty"`
-	AuthSuccessURL  string `json:"authSuccessUrl,omitempty"`
-	SessionTTLHours int    `json:"sessionTtlHours,omitempty"`
+	Managed         bool     `json:"managed,omitempty"`
+	Enabled         bool     `json:"enabled"`
+	ClientID        string   `json:"clientId,omitempty"`
+	ClientSecret    string   `json:"clientSecret,omitempty"`
+	RedirectURI     string   `json:"redirectUri,omitempty"`
+	AllowedGuildID  string   `json:"allowedGuildId,omitempty"`
+	AllowedRoleID   string   `json:"allowedRoleId,omitempty"`
+	BlockedGuildIDs []string `json:"blockedGuildIds,omitempty"`
+	AuthSuccessURL  string   `json:"authSuccessUrl,omitempty"`
+	SessionTTLHours int      `json:"sessionTtlHours,omitempty"`
 }
 
 type PublicDiscordSettings struct {
-	Enabled         bool   `json:"enabled"`
-	ClientID        string `json:"clientId"`
-	ClientSecretSet bool   `json:"clientSecretSet"`
-	RedirectURI     string `json:"redirectUri"`
-	AllowedGuildID  string `json:"allowedGuildId"`
-	AllowedRoleID   string `json:"allowedRoleId"`
-	AuthSuccessURL  string `json:"authSuccessUrl"`
-	SessionTTLHours int    `json:"sessionTtlHours"`
+	Enabled         bool     `json:"enabled"`
+	ClientID        string   `json:"clientId"`
+	ClientSecretSet bool     `json:"clientSecretSet"`
+	RedirectURI     string   `json:"redirectUri"`
+	AllowedGuildID  string   `json:"allowedGuildId"`
+	AllowedRoleID   string   `json:"allowedRoleId"`
+	BlockedGuildIDs []string `json:"blockedGuildIds"`
+	AuthSuccessURL  string   `json:"authSuccessUrl"`
+	SessionTTLHours int      `json:"sessionTtlHours"`
 }
 
 type User struct {
@@ -374,43 +376,44 @@ type CheckInRecord struct {
 }
 
 type Server struct {
-	mu                    sync.Mutex
-	openAIRefreshMu       sync.Mutex
-	keyRotationMu         sync.Mutex
-	state                 AppState
-	dataFile              string
-	databaseURL           string
-	staticDir             string
-	db                    *sql.DB
-	persistence           string
-	corsOrigin            string
-	adminToken            string
-	secretKey             []byte
-	requestLimitPerMinute int
-	providerMode          string
-	upstreamAPIKey        string
-	upstreamTimeout       time.Duration
-	httpClient            *http.Client
-	webHTTPClient         *http.Client
-	chatGPTAPIBase        string
-	openAIAuthBase        string
-	discordClientID       string
-	discordClientSecret   string
-	discordRedirectURI    string
-	discordAllowedGuildID string
-	discordAllowedRoleID  string
-	discordOAuthBase      string
-	discordAPIBase        string
-	authSuccessURL        string
-	sessionTTL            time.Duration
-	accountHealthInterval time.Duration
-	rateLimitBuckets      map[string]int
-	idempotencyCache      map[string]CachedResponse
-	authStates            map[string]time.Time
-	sessions              map[string]Session
-	openAIOAuthFlows      map[string]openAIOAuthFlow
-	requestAccounts       map[string]string
-	keyRotationOffsets    map[string]int
+	mu                     sync.Mutex
+	openAIRefreshMu        sync.Mutex
+	keyRotationMu          sync.Mutex
+	state                  AppState
+	dataFile               string
+	databaseURL            string
+	staticDir              string
+	db                     *sql.DB
+	persistence            string
+	corsOrigin             string
+	adminToken             string
+	secretKey              []byte
+	requestLimitPerMinute  int
+	providerMode           string
+	upstreamAPIKey         string
+	upstreamTimeout        time.Duration
+	httpClient             *http.Client
+	webHTTPClient          *http.Client
+	chatGPTAPIBase         string
+	openAIAuthBase         string
+	discordClientID        string
+	discordClientSecret    string
+	discordRedirectURI     string
+	discordAllowedGuildID  string
+	discordAllowedRoleID   string
+	discordBlockedGuildIDs []string
+	discordOAuthBase       string
+	discordAPIBase         string
+	authSuccessURL         string
+	sessionTTL             time.Duration
+	accountHealthInterval  time.Duration
+	rateLimitBuckets       map[string]int
+	idempotencyCache       map[string]CachedResponse
+	authStates             map[string]time.Time
+	sessions               map[string]Session
+	openAIOAuthFlows       map[string]openAIOAuthFlow
+	requestAccounts        map[string]string
+	keyRotationOffsets     map[string]int
 }
 
 // openAIOAuthFlow tracks one in-progress ChatGPT OAuth (PKCE) authorization so
@@ -575,20 +578,28 @@ type DiscordUser struct {
 	Avatar        string `json:"avatar"`
 }
 
+// DiscordUserGuild is a partial guild object from GET /users/@me/guilds, used to
+// enforce the blocked-server list (requires the "guilds" OAuth scope).
+type DiscordUserGuild struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type DiscordGuildMember struct {
 	User  DiscordUser `json:"user"`
 	Roles []string    `json:"roles"`
 }
 
 type DiscordRuntimeConfig struct {
-	ClientID       string
-	ClientSecret   string
-	RedirectURI    string
-	AllowedGuildID string
-	AllowedRoleID  string
-	OAuthBase      string
-	AuthSuccessURL string
-	SessionTTL     time.Duration
+	ClientID        string
+	ClientSecret    string
+	RedirectURI     string
+	AllowedGuildID  string
+	AllowedRoleID   string
+	BlockedGuildIDs []string
+	OAuthBase       string
+	AuthSuccessURL  string
+	SessionTTL      time.Duration
 }
 
 func main() {
@@ -700,38 +711,39 @@ func NewServer() *Server {
 	dataFile := env("DATA_FILE", "data/state.json")
 
 	s := &Server{
-		state:                 defaultState(),
-		dataFile:              dataFile,
-		databaseURL:           env("DATABASE_URL", ""),
-		staticDir:             env("STATIC_DIR", "dist"),
-		persistence:           persistence,
-		corsOrigin:            normalizeCORSOriginConfig(env("CORS_ORIGIN", "*")),
-		adminToken:            env("ADMIN_TOKEN", ""),
-		secretKey:             deriveSecretKey(env("SECRET_KEY", "")),
-		requestLimitPerMinute: envInt("REQUEST_LIMIT_PER_MINUTE", 60),
-		providerMode:          env("PROVIDER_MODE", "mock"),
-		upstreamAPIKey:        env("UPSTREAM_API_KEY", ""),
-		upstreamTimeout:       time.Duration(envInt("UPSTREAM_TIMEOUT_SECONDS", defaultUpstreamTimeoutSeconds)) * time.Second,
-		httpClient:            &http.Client{Timeout: time.Duration(envInt("UPSTREAM_TIMEOUT_SECONDS", defaultUpstreamTimeoutSeconds)) * time.Second},
-		chatGPTAPIBase:        env("CHATGPT_API_BASE", defaultChatGPTAPIBaseURL),
-		openAIAuthBase:        env("OPENAI_AUTH_BASE", "https://auth.openai.com"),
-		discordClientID:       env("DISCORD_CLIENT_ID", ""),
-		discordClientSecret:   env("DISCORD_CLIENT_SECRET", ""),
-		discordRedirectURI:    env("DISCORD_REDIRECT_URI", ""),
-		discordAllowedGuildID: env("DISCORD_ALLOWED_GUILD_ID", ""),
-		discordAllowedRoleID:  env("DISCORD_ALLOWED_ROLE_ID", ""),
-		discordOAuthBase:      env("DISCORD_OAUTH_BASE", "https://discord.com/api/oauth2"),
-		discordAPIBase:        env("DISCORD_API_BASE", "https://discord.com/api/v10"),
-		authSuccessURL:        env("AUTH_SUCCESS_URL", ""),
-		sessionTTL:            time.Duration(envInt("SESSION_TTL_HOURS", 168)) * time.Hour,
-		accountHealthInterval: 15 * time.Minute,
-		rateLimitBuckets:      map[string]int{},
-		idempotencyCache:      map[string]CachedResponse{},
-		authStates:            map[string]time.Time{},
-		sessions:              map[string]Session{},
-		openAIOAuthFlows:      map[string]openAIOAuthFlow{},
-		requestAccounts:       map[string]string{},
-		keyRotationOffsets:    map[string]int{},
+		state:                  defaultState(),
+		dataFile:               dataFile,
+		databaseURL:            env("DATABASE_URL", ""),
+		staticDir:              env("STATIC_DIR", "dist"),
+		persistence:            persistence,
+		corsOrigin:             normalizeCORSOriginConfig(env("CORS_ORIGIN", "*")),
+		adminToken:             env("ADMIN_TOKEN", ""),
+		secretKey:              deriveSecretKey(env("SECRET_KEY", "")),
+		requestLimitPerMinute:  envInt("REQUEST_LIMIT_PER_MINUTE", 60),
+		providerMode:           env("PROVIDER_MODE", "mock"),
+		upstreamAPIKey:         env("UPSTREAM_API_KEY", ""),
+		upstreamTimeout:        time.Duration(envInt("UPSTREAM_TIMEOUT_SECONDS", defaultUpstreamTimeoutSeconds)) * time.Second,
+		httpClient:             &http.Client{Timeout: time.Duration(envInt("UPSTREAM_TIMEOUT_SECONDS", defaultUpstreamTimeoutSeconds)) * time.Second},
+		chatGPTAPIBase:         env("CHATGPT_API_BASE", defaultChatGPTAPIBaseURL),
+		openAIAuthBase:         env("OPENAI_AUTH_BASE", "https://auth.openai.com"),
+		discordClientID:        env("DISCORD_CLIENT_ID", ""),
+		discordClientSecret:    env("DISCORD_CLIENT_SECRET", ""),
+		discordRedirectURI:     env("DISCORD_REDIRECT_URI", ""),
+		discordAllowedGuildID:  env("DISCORD_ALLOWED_GUILD_ID", ""),
+		discordAllowedRoleID:   env("DISCORD_ALLOWED_ROLE_ID", ""),
+		discordBlockedGuildIDs: parseGuildIDList(env("DISCORD_BLOCKED_GUILD_IDS", "")),
+		discordOAuthBase:       env("DISCORD_OAUTH_BASE", "https://discord.com/api/oauth2"),
+		discordAPIBase:         env("DISCORD_API_BASE", "https://discord.com/api/v10"),
+		authSuccessURL:         env("AUTH_SUCCESS_URL", ""),
+		sessionTTL:             time.Duration(envInt("SESSION_TTL_HOURS", 168)) * time.Hour,
+		accountHealthInterval:  15 * time.Minute,
+		rateLimitBuckets:       map[string]int{},
+		idempotencyCache:       map[string]CachedResponse{},
+		authStates:             map[string]time.Time{},
+		sessions:               map[string]Session{},
+		openAIOAuthFlows:       map[string]openAIOAuthFlow{},
+		requestAccounts:        map[string]string{},
+		keyRotationOffsets:     map[string]int{},
 	}
 	s.webHTTPClient = newChatGPTWebHTTPClient(s.upstreamTimeout)
 	s.initStorage()
@@ -925,6 +937,7 @@ func (s *Server) registerRoutes(router *gin.Engine) {
 	admin.PATCH("/channels/:id", s.updateChannel)
 	admin.DELETE("/channels/:id", s.deleteChannel)
 	admin.POST("/channels/:id/check", s.checkChannel)
+	admin.POST("/channels/:id/upstream-models", s.previewUpstreamModels)
 	admin.POST("/channels/:id/sync-models", s.syncChannelModels)
 	admin.GET("/models", s.listModels)
 	admin.POST("/models", s.createModel)
@@ -1113,6 +1126,7 @@ func (s *Server) configStatus(c *gin.Context) {
 	discordEnabled := s.discordLoginEnabledLocked()
 	discordGuildGate := s.discordAllowedGuildID != ""
 	discordRoleGate := s.discordAllowedRoleID != ""
+	discordBlockedGuildGate := len(s.discordBlockedGuildIDs) > 0
 	s.mu.Unlock()
 
 	c.JSON(http.StatusOK, gin.H{
@@ -1129,6 +1143,7 @@ func (s *Server) configStatus(c *gin.Context) {
 		"discordLoginEnabled":     discordEnabled,
 		"discordGuildGate":        discordGuildGate,
 		"discordRoleGate":         discordRoleGate,
+		"discordBlockedGuildGate": discordBlockedGuildGate,
 		"corsOrigin":              s.corsOrigin,
 		"adminAuthEnabled":        s.adminToken != "",
 		"requestLimitPerMinute":   s.requestLimitPerMinute,
@@ -1628,15 +1643,16 @@ func (s *Server) getDiscordSettings(c *gin.Context) {
 
 func (s *Server) updateDiscordSettings(c *gin.Context) {
 	var body struct {
-		Enabled           bool   `json:"enabled"`
-		ClientID          string `json:"clientId"`
-		ClientSecret      string `json:"clientSecret"`
-		ClearClientSecret bool   `json:"clearClientSecret"`
-		RedirectURI       string `json:"redirectUri"`
-		AllowedGuildID    string `json:"allowedGuildId"`
-		AllowedRoleID     string `json:"allowedRoleId"`
-		AuthSuccessURL    string `json:"authSuccessUrl"`
-		SessionTTLHours   int    `json:"sessionTtlHours"`
+		Enabled           bool     `json:"enabled"`
+		ClientID          string   `json:"clientId"`
+		ClientSecret      string   `json:"clientSecret"`
+		ClearClientSecret bool     `json:"clearClientSecret"`
+		RedirectURI       string   `json:"redirectUri"`
+		AllowedGuildID    string   `json:"allowedGuildId"`
+		AllowedRoleID     string   `json:"allowedRoleId"`
+		BlockedGuildIDs   []string `json:"blockedGuildIds"`
+		AuthSuccessURL    string   `json:"authSuccessUrl"`
+		SessionTTLHours   int      `json:"sessionTtlHours"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		s.openAIError(c, http.StatusBadRequest, "invalid_json", "Invalid JSON body", "invalid_request_error", nil)
@@ -1676,6 +1692,11 @@ func (s *Server) updateDiscordSettings(c *gin.Context) {
 	}
 	if body.AllowedRoleID != "" && !digitsOnly(body.AllowedRoleID) {
 		validationError(c, "Discord 身份组 ID 只能包含数字")
+		return
+	}
+	blockedGuildIDs, invalidBlocked := sanitizeGuildIDList(body.BlockedGuildIDs)
+	if invalidBlocked != "" {
+		validationError(c, "拉黑服务器 ID 只能包含数字")
 		return
 	}
 	if body.RedirectURI != "" && !validHTTPURL(body.RedirectURI) {
@@ -1733,6 +1754,7 @@ func (s *Server) updateDiscordSettings(c *gin.Context) {
 		RedirectURI:     body.RedirectURI,
 		AllowedGuildID:  body.AllowedGuildID,
 		AllowedRoleID:   body.AllowedRoleID,
+		BlockedGuildIDs: blockedGuildIDs,
 		AuthSuccessURL:  body.AuthSuccessURL,
 		SessionTTLHours: body.SessionTTLHours,
 	}
@@ -1741,6 +1763,7 @@ func (s *Server) updateDiscordSettings(c *gin.Context) {
 	s.discordRedirectURI = body.RedirectURI
 	s.discordAllowedGuildID = body.AllowedGuildID
 	s.discordAllowedRoleID = body.AllowedRoleID
+	s.discordBlockedGuildIDs = blockedGuildIDs
 	s.authSuccessURL = body.AuthSuccessURL
 	s.sessionTTL = time.Duration(body.SessionTTLHours) * time.Hour
 	if !body.Enabled {
@@ -1770,6 +1793,7 @@ func (s *Server) publicDiscordSettingsLocked(origin string) PublicDiscordSetting
 			RedirectURI:     redirectURI,
 			AllowedGuildID:  s.discordAllowedGuildID,
 			AllowedRoleID:   s.discordAllowedRoleID,
+			BlockedGuildIDs: append([]string{}, s.discordBlockedGuildIDs...),
 			AuthSuccessURL:  authSuccessURL,
 			SessionTTLHours: int(s.sessionTTL.Hours()),
 		}
@@ -1789,6 +1813,7 @@ func (s *Server) publicDiscordSettingsLocked(origin string) PublicDiscordSetting
 		RedirectURI:     redirectURI,
 		AllowedGuildID:  settings.AllowedGuildID,
 		AllowedRoleID:   settings.AllowedRoleID,
+		BlockedGuildIDs: append([]string{}, settings.BlockedGuildIDs...),
 		AuthSuccessURL:  authSuccessURL,
 		SessionTTLHours: settings.SessionTTLHours,
 	}
@@ -1814,7 +1839,13 @@ func (s *Server) discordStart(c *gin.Context) {
 	values.Set("client_id", config.ClientID)
 	values.Set("redirect_uri", config.RedirectURI)
 	values.Set("response_type", "code")
-	values.Set("scope", "identify guilds.members.read")
+	// The "guilds" scope is only needed to read the user's guild list for the
+	// blocked-server check, so request it only when a blacklist is configured.
+	scope := "identify guilds.members.read"
+	if len(config.BlockedGuildIDs) > 0 {
+		scope += " guilds"
+	}
+	values.Set("scope", scope)
 	values.Set("state", state)
 	c.Redirect(http.StatusFound, strings.TrimRight(config.OAuthBase, "/")+"/authorize?"+values.Encode())
 }
@@ -1845,6 +1876,21 @@ func (s *Server) discordCallback(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": err.Error()}})
 		return
+	}
+
+	// Enforce the blocked-server list before any login or registration: a user
+	// who belongs to any blacklisted guild is denied outright, even if already
+	// bound to a local account.
+	if len(config.BlockedGuildIDs) > 0 {
+		guilds, err := s.fetchDiscordUserGuilds(token.AccessToken)
+		if err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": err.Error()}})
+			return
+		}
+		if firstBlockedGuild(guilds, config.BlockedGuildIDs) != "" {
+			c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"message": "你所在的 Discord 服务器已被限制登录"}})
+			return
+		}
 	}
 
 	s.mu.Lock()
@@ -3498,6 +3544,14 @@ func (s *Server) deleteChannel(c *gin.Context) {
 }
 
 func (s *Server) syncChannelModels(c *gin.Context) {
+	// An optional models list lets the admin commit an explicit selection (from
+	// the model picker) instead of importing every model the upstream returns.
+	var body struct {
+		Models []string `json:"models"`
+	}
+	_ = c.ShouldBindJSON(&body)
+	selected := mergeStrings(nil, body.Models)
+
 	s.mu.Lock()
 	channel := s.findChannel(c.Param("id"))
 	if channel == nil {
@@ -3507,7 +3561,7 @@ func (s *Server) syncChannelModels(c *gin.Context) {
 	}
 	channelCopy := *channel
 	upstreamKey := ""
-	if !isCodexChannel(channelCopy) {
+	if len(selected) == 0 && !isCodexChannel(channelCopy) {
 		var err error
 		upstreamKey, err = s.channelUpstreamKey(channelCopy)
 		if err != nil {
@@ -3518,14 +3572,18 @@ func (s *Server) syncChannelModels(c *gin.Context) {
 	}
 	s.mu.Unlock()
 
-	modelIDs, err := s.fetchUpstreamModelIDs(channelCopy, upstreamKey)
-	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": err.Error()}})
-		return
-	}
+	modelIDs := selected
 	if len(modelIDs) == 0 {
-		c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": "上游未返回可用模型"}})
-		return
+		var err error
+		modelIDs, err = s.fetchUpstreamModelIDs(channelCopy, upstreamKey)
+		if err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": err.Error()}})
+			return
+		}
+		if len(modelIDs) == 0 {
+			c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": "上游未返回可用模型"}})
+			return
+		}
 	}
 
 	s.mu.Lock()
@@ -3571,6 +3629,35 @@ func (s *Server) syncChannelModels(c *gin.Context) {
 	removedModels := s.pruneUnreferencedImportedModelsLocked()
 	s.saveStateLocked()
 	c.JSON(http.StatusOK, gin.H{"channel": publicChannel(*channel), "models": channel.Models, "addedModels": added, "removedModels": removedModels})
+}
+
+func (s *Server) previewUpstreamModels(c *gin.Context) {
+	s.mu.Lock()
+	channel := s.findChannel(c.Param("id"))
+	if channel == nil {
+		s.mu.Unlock()
+		c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"message": "Channel not found"}})
+		return
+	}
+	channelCopy := *channel
+	upstreamKey := ""
+	if !isCodexChannel(channelCopy) {
+		var err error
+		upstreamKey, err = s.channelUpstreamKey(channelCopy)
+		if err != nil {
+			s.mu.Unlock()
+			c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": err.Error()}})
+			return
+		}
+	}
+	s.mu.Unlock()
+
+	modelIDs, err := s.fetchUpstreamModelIDs(channelCopy, upstreamKey)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": err.Error()}})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"models": modelIDs})
 }
 
 func (s *Server) checkChannel(c *gin.Context) {
@@ -7889,14 +7976,15 @@ func (s *Server) discordRuntimeConfig(c *gin.Context) DiscordRuntimeConfig {
 		authSuccessURL = requestOrigin(c) + "/"
 	}
 	return DiscordRuntimeConfig{
-		ClientID:       s.discordClientID,
-		ClientSecret:   s.discordClientSecret,
-		RedirectURI:    redirectURI,
-		AllowedGuildID: s.discordAllowedGuildID,
-		AllowedRoleID:  s.discordAllowedRoleID,
-		OAuthBase:      s.discordOAuthBase,
-		AuthSuccessURL: authSuccessURL,
-		SessionTTL:     s.sessionTTL,
+		ClientID:        s.discordClientID,
+		ClientSecret:    s.discordClientSecret,
+		RedirectURI:     redirectURI,
+		AllowedGuildID:  s.discordAllowedGuildID,
+		AllowedRoleID:   s.discordAllowedRoleID,
+		BlockedGuildIDs: append([]string(nil), s.discordBlockedGuildIDs...),
+		OAuthBase:       s.discordOAuthBase,
+		AuthSuccessURL:  authSuccessURL,
+		SessionTTL:      s.sessionTTL,
 	}
 }
 
@@ -7962,6 +8050,14 @@ func (s *Server) fetchDiscordGuildMember(accessToken string, guildID string) (*D
 		return nil, err
 	}
 	return &member, nil
+}
+
+func (s *Server) fetchDiscordUserGuilds(accessToken string) ([]DiscordUserGuild, error) {
+	var guilds []DiscordUserGuild
+	if err := s.discordGet(accessToken, "/users/@me/guilds", &guilds); err != nil {
+		return nil, err
+	}
+	return guilds, nil
 }
 
 func (s *Server) discordGet(accessToken string, path string, target interface{}) error {
@@ -8765,6 +8861,65 @@ func digitsOnly(value string) bool {
 	return true
 }
 
+// parseGuildIDList splits a comma/space/newline separated list of Discord guild
+// IDs, keeping only digit-only values and dropping blanks and duplicates.
+func parseGuildIDList(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\n' || r == '\r' || r == '\t'
+	})
+	seen := map[string]bool{}
+	ids := []string{}
+	for _, field := range fields {
+		id := strings.TrimSpace(field)
+		if id == "" || !digitsOnly(id) || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// sanitizeGuildIDList validates and de-duplicates an incoming ID list. It returns
+// the cleaned list and the first invalid (non-digit) value found, if any.
+func sanitizeGuildIDList(values []string) ([]string, string) {
+	seen := map[string]bool{}
+	ids := []string{}
+	for _, value := range values {
+		id := strings.TrimSpace(value)
+		if id == "" {
+			continue
+		}
+		if !digitsOnly(id) {
+			return nil, id
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids, ""
+}
+
+// firstBlockedGuild returns the ID of the first guild the user belongs to that
+// appears in the blocked list, or "" when none match.
+func firstBlockedGuild(guilds []DiscordUserGuild, blocked []string) string {
+	if len(blocked) == 0 {
+		return ""
+	}
+	blockedSet := map[string]bool{}
+	for _, id := range blocked {
+		blockedSet[id] = true
+	}
+	for _, guild := range guilds {
+		if blockedSet[guild.ID] {
+			return guild.ID
+		}
+	}
+	return ""
+}
+
 func validHTTPURL(value string) bool {
 	parsed, err := url.Parse(value)
 	return err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != ""
@@ -9548,6 +9703,7 @@ func (s *Server) applyPersistedDiscordSettings() {
 	s.discordRedirectURI = settings.RedirectURI
 	s.discordAllowedGuildID = settings.AllowedGuildID
 	s.discordAllowedRoleID = settings.AllowedRoleID
+	s.discordBlockedGuildIDs = append([]string{}, settings.BlockedGuildIDs...)
 	s.authSuccessURL = settings.AuthSuccessURL
 	if settings.SessionTTLHours > 0 {
 		s.sessionTTL = time.Duration(settings.SessionTTLHours) * time.Hour

--- a/cmd/capi/main_test.go
+++ b/cmd/capi/main_test.go
@@ -1491,6 +1491,102 @@ func TestSyncChannelModelsPullsFromUpstream(t *testing.T) {
 	}
 }
 
+func TestPreviewUpstreamModelsListsWithoutCommitting(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("upstream path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"preview-model-a"},{"id":"preview-model-b"}]}`))
+	}))
+	defer upstream.Close()
+
+	withEnv(t, map[string]string{"PERSISTENCE": "memory"})
+	_, router := testServerRouter(t)
+
+	created := perform(router, http.MethodPost, "/api/channels", `{"name":"Upstream","baseUrl":"`+upstream.URL+`/v1","upstreamApiKey":"preview-secret","models":["existing-model"]}`, nil)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create channel status = %d body = %s", created.Code, created.Body.String())
+	}
+	var payload struct {
+		Channel PublicChannel `json:"channel"`
+	}
+	if err := json.Unmarshal(created.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode channel: %v", err)
+	}
+
+	preview := perform(router, http.MethodPost, "/api/channels/"+payload.Channel.ID+"/upstream-models", `{}`, nil)
+	if preview.Code != http.StatusOK {
+		t.Fatalf("preview status = %d body = %s", preview.Code, preview.Body.String())
+	}
+	if !bytes.Contains(preview.Body.Bytes(), []byte(`preview-model-a`)) || !bytes.Contains(preview.Body.Bytes(), []byte(`preview-model-b`)) {
+		t.Fatalf("preview missing upstream ids: %s", preview.Body.String())
+	}
+
+	// Preview is read-only: it must not attach models to the channel or create
+	// catalog entries the way sync-models does.
+	channels := perform(router, http.MethodGet, "/api/channels", "", nil)
+	if bytes.Contains(channels.Body.Bytes(), []byte(`preview-model-a`)) {
+		t.Fatalf("preview should not attach models to channel: %s", channels.Body.String())
+	}
+	models := perform(router, http.MethodGet, "/api/models", "", nil)
+	if bytes.Contains(models.Body.Bytes(), []byte(`"id":"preview-model-a"`)) {
+		t.Fatalf("preview should not create catalog models: %s", models.Body.String())
+	}
+}
+
+func TestSyncChannelModelsAcceptsExplicitSelection(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"provider-model-a"},{"id":"provider-model-b"},{"id":"provider-model-c"}]}`))
+	}))
+	defer upstream.Close()
+
+	withEnv(t, map[string]string{"PERSISTENCE": "memory"})
+	_, router := testServerRouter(t)
+
+	created := perform(router, http.MethodPost, "/api/channels", `{"name":"Upstream","baseUrl":"`+upstream.URL+`/v1","upstreamApiKey":"sync-secret","models":["stale-provider-model"]}`, nil)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create channel status = %d body = %s", created.Code, created.Body.String())
+	}
+	var payload struct {
+		Channel PublicChannel `json:"channel"`
+	}
+	if err := json.Unmarshal(created.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode channel: %v", err)
+	}
+
+	// An explicit selection commits exactly those models and must not query upstream.
+	synced := perform(router, http.MethodPost, "/api/channels/"+payload.Channel.ID+"/sync-models", `{"models":["provider-model-a","provider-model-c"]}`, nil)
+	if synced.Code != http.StatusOK {
+		t.Fatalf("sync models status = %d body = %s", synced.Code, synced.Body.String())
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("explicit selection should not query upstream, hits = %d", upstreamHits)
+	}
+
+	channels := perform(router, http.MethodGet, "/api/channels", "", nil)
+	if !bytes.Contains(channels.Body.Bytes(), []byte(`provider-model-a`)) || !bytes.Contains(channels.Body.Bytes(), []byte(`provider-model-c`)) {
+		t.Fatalf("channel missing selected models: %s", channels.Body.String())
+	}
+	if bytes.Contains(channels.Body.Bytes(), []byte(`provider-model-b`)) {
+		t.Fatalf("channel should not contain unselected model: %s", channels.Body.String())
+	}
+	if bytes.Contains(channels.Body.Bytes(), []byte(`stale-provider-model`)) {
+		t.Fatalf("stale model should be replaced by selection: %s", channels.Body.String())
+	}
+
+	models := perform(router, http.MethodGet, "/api/models", "", nil)
+	if !bytes.Contains(models.Body.Bytes(), []byte(`"id":"provider-model-a"`)) {
+		t.Fatalf("selected model was not created in catalog: %s", models.Body.String())
+	}
+	if bytes.Contains(models.Body.Bytes(), []byte(`"id":"provider-model-b"`)) {
+		t.Fatalf("unselected model should not be created in catalog: %s", models.Body.String())
+	}
+}
+
 func TestSyncChannelModelsRetriesWithAnthropicAuth(t *testing.T) {
 	requests := 0
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4225,6 +4321,111 @@ func TestDiscordOAuthRoleGateCreatesSessionForAdminRoutes(t *testing.T) {
 	users := perform(router, http.MethodGet, "/api/users", "", map[string]string{"Cookie": cookies[0].Name + "=" + cookies[0].Value})
 	if users.Code != http.StatusOK {
 		t.Fatalf("session did not authorize admin route: %d body = %s", users.Code, users.Body.String())
+	}
+}
+
+func TestDiscordBlockedGuildDeniesLogin(t *testing.T) {
+	blockedGuildID := "999000111000111000"
+	discord := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"discord-access","token_type":"Bearer","expires_in":3600,"scope":"identify guilds.members.read guilds"}`))
+		case "/api/v10/users/@me":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"dc_user_blocked","username":"capi","global_name":"CAPI"}`))
+		case "/api/v10/users/@me/guilds":
+			if r.Header.Get("Authorization") != "Bearer discord-access" {
+				t.Fatalf("guild list auth = %s", r.Header.Get("Authorization"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"111","name":"Fine"},{"id":"` + blockedGuildID + `","name":"Blocked"}]`))
+		default:
+			t.Fatalf("unexpected discord path: %s", r.URL.Path)
+		}
+	}))
+	defer discord.Close()
+
+	withEnv(t, map[string]string{
+		"PERSISTENCE":               "memory",
+		"ADMIN_TOKEN":               "admin-secret",
+		"DISCORD_CLIENT_ID":         "client-id",
+		"DISCORD_CLIENT_SECRET":     "client-secret",
+		"DISCORD_REDIRECT_URI":      "http://localhost:8787/api/auth/discord/callback",
+		"DISCORD_BLOCKED_GUILD_IDS": blockedGuildID,
+		"DISCORD_OAUTH_BASE":        discord.URL + "/oauth2",
+		"DISCORD_API_BASE":          discord.URL + "/api/v10",
+		"AUTH_SUCCESS_URL":          "http://localhost:5173/",
+	})
+	router := testRouter(t)
+
+	start := perform(router, http.MethodGet, "/api/auth/discord/start", "", nil)
+	if start.Code != http.StatusFound {
+		t.Fatalf("discord start status = %d body = %s", start.Code, start.Body.String())
+	}
+	authURL, err := url.Parse(start.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+	if !strings.Contains(authURL.Query().Get("scope"), "guilds.members.read guilds") {
+		t.Fatalf("blocked-guild config should append the guilds scope: %s", authURL.Query().Get("scope"))
+	}
+	state := authURL.Query().Get("state")
+
+	callback := perform(router, http.MethodGet, "/api/auth/discord/callback?code=oauth-code&state="+url.QueryEscape(state), "", nil)
+	if callback.Code != http.StatusForbidden {
+		t.Fatalf("blocked guild member should be denied, status = %d body = %s", callback.Code, callback.Body.String())
+	}
+	if len(callback.Result().Cookies()) != 0 {
+		t.Fatal("blocked guild member should not receive a session cookie")
+	}
+}
+
+func TestDiscordBlockedGuildAllowsNonMember(t *testing.T) {
+	blockedGuildID := "999000111000111000"
+	discord := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"discord-access","token_type":"Bearer","expires_in":3600}`))
+		case "/api/v10/users/@me":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"dc_user_ok","username":"capi","global_name":"CAPI"}`))
+		case "/api/v10/users/@me/guilds":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"111","name":"Fine"},{"id":"222","name":"Also Fine"}]`))
+		default:
+			t.Fatalf("unexpected discord path: %s", r.URL.Path)
+		}
+	}))
+	defer discord.Close()
+
+	withEnv(t, map[string]string{
+		"PERSISTENCE":               "memory",
+		"ADMIN_TOKEN":               "admin-secret",
+		"DISCORD_CLIENT_ID":         "client-id",
+		"DISCORD_CLIENT_SECRET":     "client-secret",
+		"DISCORD_REDIRECT_URI":      "http://localhost:8787/api/auth/discord/callback",
+		"DISCORD_BLOCKED_GUILD_IDS": blockedGuildID,
+		"DISCORD_OAUTH_BASE":        discord.URL + "/oauth2",
+		"DISCORD_API_BASE":          discord.URL + "/api/v10",
+		"AUTH_SUCCESS_URL":          "http://localhost:5173/",
+	})
+	router := testRouter(t)
+
+	start := perform(router, http.MethodGet, "/api/auth/discord/start", "", nil)
+	authURL, err := url.Parse(start.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+	state := authURL.Query().Get("state")
+
+	callback := perform(router, http.MethodGet, "/api/auth/discord/callback?code=oauth-code&state="+url.QueryEscape(state), "", nil)
+	if callback.Code != http.StatusFound {
+		t.Fatalf("non-member should be allowed, status = %d body = %s", callback.Code, callback.Body.String())
+	}
+	if len(callback.Result().Cookies()) == 0 {
+		t.Fatal("non-member should receive a session cookie")
 	}
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -240,6 +240,7 @@ type DiscordSettings = {
   redirectUri: string;
   allowedGuildId: string;
   allowedRoleId: string;
+  blockedGuildIds: string[];
   authSuccessUrl: string;
   sessionTtlHours: number;
 };
@@ -772,6 +773,7 @@ function withBrowserDiscordDefaults(settings: DiscordSettings): DiscordSettings 
     ...settings,
     redirectUri: settings.redirectUri && !settings.redirectUri.includes("localhost") ? settings.redirectUri : defaultDiscordRedirectUri(),
     authSuccessUrl: settings.authSuccessUrl && !settings.authSuccessUrl.includes("localhost") ? settings.authSuccessUrl : defaultAuthSuccessUrl(),
+    blockedGuildIds: arrayOf(settings.blockedGuildIds),
     sessionTtlHours: settings.sessionTtlHours || 168
   };
 }
@@ -937,10 +939,11 @@ function App() {
     window.setTimeout(() => setToast(""), 1800);
   }
 
-  async function syncChannelModels(id: string) {
+  async function syncChannelModels(id: string, models?: string[]) {
+    const explicit = arrayOf(models).map((model) => model.trim()).filter(Boolean);
     const data = await fetchJson<ChannelSyncResult>(`/api/channels/${id}/sync-models`, {
       method: "POST",
-      body: JSON.stringify({})
+      body: JSON.stringify(explicit.length ? { models: explicit } : {})
     });
     const syncedChannel = normalizeChannel(data.channel);
     const addedModels = arrayOf(data.addedModels).map(normalizeModel);
@@ -953,7 +956,7 @@ function App() {
       });
     }
     removeModelsFromCatalog(data.removedModels);
-    setToast(syncedModels.length ? `已拉取 ${syncedModels.length} 个模型` : "上游没有返回模型");
+    setToast(explicit.length ? `已保存 ${syncedModels.length} 个模型` : syncedModels.length ? `已拉取 ${syncedModels.length} 个模型` : "上游没有返回模型");
     window.setTimeout(() => setToast(""), 2200);
   }
 
@@ -1677,8 +1680,12 @@ function AccountHome({
           {message && <p className="account-message">{message}</p>}
           <div className="account-key-list">
             {data?.apiKeys?.map((key) => (
-              <div key={key.id}>
-                <span><strong>{key.name}</strong><small>{key.prefix}...</small></span>
+              <div key={key.id} className="account-key-item">
+                <span className="account-key-mark" aria-hidden="true"><Icon name="key" /></span>
+                <div className="account-key-info">
+                  <strong>{key.name}</strong>
+                  <code>{key.prefix}…</code>
+                </div>
                 <Badge tone={key.status}>{statusLabel(key.status)}</Badge>
               </div>
             ))}
@@ -3252,7 +3259,7 @@ function ChannelsView({
   onCreate: (channel: ChannelCreate) => Promise<void>;
   onImport: (channelId: string, file: File) => Promise<void>;
   onDelete: (id: string) => void;
-  onSyncModels: (id: string) => Promise<void>;
+  onSyncModels: (id: string, models?: string[]) => Promise<void>;
   onCheck: (id: string) => Promise<void>;
 }) {
   const initialTemplate = channelTemplateFor("openai");
@@ -3385,7 +3392,7 @@ function ChannelEditor({
   onUpdate: (id: string, patch: ChannelPatch) => Promise<void>;
   onImport: (channelId: string, file: File) => Promise<void>;
   onDelete: (id: string) => void;
-  onSyncModels: (id: string) => Promise<void>;
+  onSyncModels: (id: string, models?: string[]) => Promise<void>;
   onCheck: (id: string) => Promise<void>;
 }) {
   const [name, setName] = useState(channel.name);
@@ -3399,6 +3406,7 @@ function ChannelEditor({
   const [webEndpoint, setWebEndpoint] = useState(Boolean(channel.webEndpoint));
   const [upstreamApiKey, setUpstreamApiKey] = useState("");
   const [busy, setBusy] = useState("");
+  const [pickerOpen, setPickerOpen] = useState(false);
   const accountCount = channel.openaiAccountCount ?? channel.openaiAccounts?.length ?? 0;
   const modelCount = arrayOf(channel.models).length;
   const capabilities = channelCapabilities(channel);
@@ -3474,12 +3482,13 @@ function ChannelEditor({
     }
   }
 
-  async function syncModels() {
+  async function openModelPicker() {
     setBusy("sync");
     try {
-      await save();
-      await onSyncModels(channel.id);
-      setModelSource("synced");
+      // Persist any edits (Base URL / key) so the preview queries the live upstream.
+      await onUpdate(channel.id, currentChannelPatch());
+      setUpstreamApiKey("");
+      setPickerOpen(true);
     } finally {
       setBusy("");
     }
@@ -3514,6 +3523,7 @@ function ChannelEditor({
   }
 
   return (
+    <>
     <details className="channel-card channel-card-collapsible">
       <summary className="channel-card-head channel-list-row">
         <div className="channel-identity">
@@ -3631,7 +3641,7 @@ function ChannelEditor({
             <button type="button" className="secondary-button compact-button" onClick={fillTemplateModels} disabled={busy !== ""}>
               填入模板
             </button>
-            <button type="button" className="secondary-button compact-button" onClick={syncModels} disabled={busy !== ""}>
+            <button type="button" className="secondary-button compact-button" onClick={openModelPicker} disabled={busy !== ""}>
               {busy === "sync" ? "拉取中" : "获取上游模型"}
             </button>
           </div>
@@ -3675,6 +3685,174 @@ function ChannelEditor({
         </details>
       </div>
     </details>
+    {pickerOpen && (
+      <ModelPickerModal
+        channelId={channel.id}
+        channelName={channel.name}
+        current={models.split(",").map((model) => model.trim()).filter(Boolean)}
+        onConfirm={async (selectedModels) => { await onSyncModels(channel.id, selectedModels); }}
+        onClose={() => setPickerOpen(false)}
+      />
+    )}
+    </>
+  );
+}
+
+function ModelPickerModal({
+  channelId,
+  channelName,
+  current,
+  onConfirm,
+  onClose
+}: {
+  channelId: string;
+  channelName: string;
+  current: string[];
+  onConfirm: (models: string[]) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [upstream, setUpstream] = useState<string[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await fetchJson<{ models?: string[] }>(`/api/channels/${channelId}/upstream-models`, {
+          method: "POST",
+          body: JSON.stringify({})
+        });
+        if (cancelled) return;
+        const seen = new Set<string>();
+        const unique = arrayOf(data.models).map((model) => model.trim()).filter((model) => {
+          if (!model) return false;
+          const key = model.toLowerCase();
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+        const currentLower = new Set(current.map((model) => model.toLowerCase()));
+        setUpstream(unique);
+        setSelected(new Set(unique.filter((model) => currentLower.has(model.toLowerCase()))));
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "获取上游模型失败");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // Fetch once per open; `current` is only used to seed the initial checkboxes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channelId]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = normalizedQuery ? upstream.filter((model) => model.toLowerCase().includes(normalizedQuery)) : upstream;
+  const allVisibleSelected = filtered.length > 0 && filtered.every((model) => selected.has(model));
+
+  function toggle(model: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(model)) next.delete(model);
+      else next.add(model);
+      return next;
+    });
+  }
+
+  function toggleAllVisible() {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allVisibleSelected) filtered.forEach((model) => next.delete(model));
+      else filtered.forEach((model) => next.add(model));
+      return next;
+    });
+  }
+
+  async function confirm() {
+    // Final list = the picked upstream models plus any existing custom models the
+    // upstream does not expose, so manually added entries are never dropped.
+    const upstreamLower = new Set(upstream.map((model) => model.toLowerCase()));
+    const preserved = current.filter((model) => !upstreamLower.has(model.toLowerCase()));
+    const picked = upstream.filter((model) => selected.has(model));
+    const seen = new Set<string>();
+    const finalList = [...preserved, ...picked].filter((model) => {
+      const key = model.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    setSaving(true);
+    try {
+      await onConfirm(finalList);
+      onClose();
+    } catch {
+      // onConfirm surfaces its own toast on failure; keep the picker open to retry.
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal-card model-picker-modal" onClick={(event) => event.stopPropagation()}>
+        <div className="modal-head">
+          <div>
+            <strong>选择上游模型</strong>
+            <span>{channelName} · 勾选需要接入的模型</span>
+          </div>
+          <button type="button" className="icon-button" onClick={onClose}>×</button>
+        </div>
+        {loading ? (
+          <div className="model-picker-status">正在获取上游模型…</div>
+        ) : error ? (
+          <div className="model-picker-status model-picker-error">{error}</div>
+        ) : (
+          <>
+            <div className="model-picker-toolbar">
+              <input
+                className="model-picker-search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="搜索模型名称"
+                autoFocus
+              />
+              <button type="button" className="secondary-button compact-button" onClick={toggleAllVisible} disabled={filtered.length === 0}>
+                {allVisibleSelected ? "取消全选" : "全选"}
+              </button>
+            </div>
+            <div className="model-picker-count">
+              共 {upstream.length} 个 · 已选 {selected.size} 个{normalizedQuery ? ` · 匹配 ${filtered.length} 个` : ""}
+            </div>
+            <div className="model-picker-list">
+              {filtered.map((model) => {
+                const checked = selected.has(model);
+                const already = current.some((item) => item.toLowerCase() === model.toLowerCase());
+                return (
+                  <label key={model} className={`model-picker-row${checked ? " checked" : ""}`}>
+                    <input type="checkbox" checked={checked} onChange={() => toggle(model)} />
+                    <span className="model-picker-name">{model}</span>
+                    {already && <span className="model-picker-tag">已接入</span>}
+                  </label>
+                );
+              })}
+              {filtered.length === 0 && <div className="model-picker-status">没有匹配的模型</div>}
+            </div>
+          </>
+        )}
+        <div className="modal-actions">
+          <button type="button" className="secondary-button" onClick={onClose}>取消</button>
+          <button type="button" className="primary-button" disabled={loading || Boolean(error) || saving} onClick={confirm}>
+            {saving ? "保存中" : `导入所选 (${selected.size})`}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -3895,6 +4073,7 @@ function SettingsView({ models, channels }: { models: ModelItem[]; channels: Cha
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [clientSecret, setClientSecret] = useState("");
+  const [blockedGuildText, setBlockedGuildText] = useState("");
   const [message, setMessage] = useState("");
   const [saving, setSaving] = useState(false);
   const [settingsTab, setSettingsTab] = useState("system");
@@ -3923,6 +4102,7 @@ function SettingsView({ models, channels }: { models: ModelItem[]; channels: Cha
     ])
       .then(([discordData, authData, checkInData, accountData, maintenanceData, healthData]) => {
         setDiscord(withBrowserDiscordDefaults(discordData.discord));
+        setBlockedGuildText(arrayOf(discordData.discord.blockedGuildIds).join("\n"));
         setRegistrationEnabled(authData.auth.registrationEnabled);
         setRegistrationMode(normalizeRegistrationMode(authData.auth.registrationMode));
         setDefaultBalance(String(authData.auth.defaultBalance || 0));
@@ -3982,11 +4162,13 @@ function SettingsView({ models, channels }: { models: ModelItem[]; channels: Cha
     setMessage("");
     try {
       const nextDiscord = withBrowserDiscordDefaults(discord);
+      const blockedGuildIds = blockedGuildText.split(/[\s,]+/).map((id) => id.trim()).filter(Boolean);
       const data = await fetchJson<{ discord: DiscordSettings }>("/api/settings/discord", {
         method: "PATCH",
-        body: JSON.stringify({ ...nextDiscord, clientSecret })
+        body: JSON.stringify({ ...nextDiscord, blockedGuildIds, clientSecret })
       });
       setDiscord(withBrowserDiscordDefaults(data.discord));
+      setBlockedGuildText(arrayOf(data.discord.blockedGuildIds).join("\n"));
       setClientSecret("");
       setMessage("Discord 配置已保存");
     } catch (error) {
@@ -4538,6 +4720,16 @@ response = client.chat.completions.create(
                   onChange={(event) => setDiscord({ ...discord, allowedRoleId: event.target.value })}
                   placeholder="允许登录的身份组 ID"
                 />
+              </label>
+              <label className="settings-form-wide">
+                <span>拉黑服务器 ID</span>
+                <textarea
+                  value={blockedGuildText}
+                  onChange={(event) => setBlockedGuildText(event.target.value)}
+                  placeholder="每行一个服务器 ID；命中的用户禁止注册 / 登录"
+                  rows={3}
+                />
+                <small>用户若加入了这些 Discord 服务器中的任意一个，将无法注册或登录（优先于上面的允许规则）。</small>
               </label>
               <label className="settings-form-wide">
                 <span>登录成功跳转地址</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1738,6 +1738,7 @@ h3 {
 .app-shell[data-theme="dark"] .provider-picker-trigger,
 .app-shell[data-theme="dark"] .key-editor-grid input,
 .app-shell[data-theme="dark"] .settings-form-grid input,
+.app-shell[data-theme="dark"] .settings-form-grid textarea,
 .app-shell[data-theme="dark"] .maintenance-control input,
 .app-shell[data-theme="dark"] .bulk-action-bar input,
 .app-shell[data-theme="dark"] .auth-default-balance input {
@@ -1866,6 +1867,18 @@ button.table-row:hover {
 
 .channel-create-form {
   margin-bottom: 14px;
+}
+
+/* The create form has fewer fields than the editor, so the editor's 3-column
+   grid (1.4/0.5/0.7) left ragged empty columns. A tidy two-column grid keeps
+   name/provider side by side and lets the wide fields fill the row cleanly. */
+.channel-create-form .channel-form-grid {
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.channel-create-form .channel-form-wide {
+  grid-column: 1 / -1;
 }
 
 .channel-card {
@@ -2875,6 +2888,34 @@ button.table-row:hover {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--blue) 18%, transparent);
 }
 
+.settings-form-grid textarea {
+  width: 100%;
+  min-width: 0;
+  min-height: 88px;
+  padding: 10px 12px;
+  color: var(--text);
+  background: var(--group);
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  outline: none;
+  resize: vertical;
+  font: inherit;
+  line-height: 1.5;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--muted) 55%, transparent) transparent;
+}
+
+.settings-form-grid textarea:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--blue) 18%, transparent);
+}
+
+.settings-form-grid small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .settings-form-grid input::placeholder {
   color: var(--muted);
   opacity: 0.72;
@@ -3480,9 +3521,9 @@ button.table-row:hover {
 .account-key-list > div {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: 58px;
+  gap: 13px;
+  min-height: 66px;
+  padding: 13px 6px;
   border-top: 1px solid var(--hairline);
 }
 
@@ -3490,14 +3531,52 @@ button.table-row:hover {
   border-top: 0;
 }
 
-.account-key-list span,
-.account-key-list small {
-  display: block;
+.account-key-list .empty {
+  justify-content: center;
 }
 
-.account-key-list small {
-  margin-top: 4px;
+.account-key-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  color: var(--blue);
+  background: color-mix(in srgb, var(--blue) 13%, transparent);
+  border-radius: 12px;
+}
+
+.account-key-mark .icon {
+  width: 19px;
+  height: 19px;
+}
+
+.account-key-info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.account-key-info strong {
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.account-key-info code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  letter-spacing: 0.01em;
   color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.account-key-list .badge {
+  flex: 0 0 auto;
+  align-self: center;
 }
 
 .account-model-grid {
@@ -4700,6 +4779,107 @@ button.table-row:hover {
   justify-content: flex-end;
   gap: 10px;
   margin-top: 20px;
+}
+
+/* Upstream model picker (newapi-style multi-select dialog) */
+.model-picker-modal {
+  max-width: 560px;
+}
+
+.model-picker-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.model-picker-search {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 38px;
+  padding: 0 12px;
+  color: var(--text);
+  background: var(--group);
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  outline: none;
+}
+
+.model-picker-search:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--blue) 18%, transparent);
+}
+
+.model-picker-count {
+  margin: 10px 2px 8px;
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.model-picker-list {
+  display: grid;
+  gap: 4px;
+  max-height: 46vh;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid var(--hairline);
+  border-radius: 14px;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--muted) 55%, transparent) transparent;
+}
+
+.model-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 11px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.model-picker-row:hover {
+  background: var(--group);
+}
+
+.model-picker-row.checked {
+  background: color-mix(in srgb, var(--blue) 10%, var(--group));
+}
+
+.model-picker-row input[type="checkbox"] {
+  flex: 0 0 auto;
+  width: 17px;
+  height: 17px;
+  accent-color: var(--blue);
+  cursor: pointer;
+}
+
+.model-picker-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 13.5px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.model-picker-tag {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  color: var(--blue);
+  background: color-mix(in srgb, var(--blue) 14%, transparent);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.model-picker-status {
+  padding: 26px 12px;
+  color: var(--muted);
+  text-align: center;
+  font-size: 13px;
+}
+
+.model-picker-error {
+  color: #d70015;
 }
 
 .form-error {


### PR DESCRIPTION
## 概述
本次改动包含三块 UI 优化 + 一个新功能（Discord 服务器拉黑）。

## UI 修复
- **用户中心 API 密钥卡片**：修复"正常"状态徽章错位（`.account-key-list span { display: block }` 覆盖了徽章的 `inline-flex` 导致内部失去垂直居中），并把卡片做得更丰富（钥匙图标 + 等宽前缀）。
- **新增渠道表单**：改用独立的两列栅格，字段不再留下参差的空列。
- **拉取模型弹窗**：新增 newapi 风格的模型选择弹窗——把上游模型列表拉进一个可搜索的多选对话框，勾选后再导入，而不是一次性导入全部。

## 新功能：Discord 服务器拉黑
- 后台 Discord 设置新增「拉黑服务器 ID」（也支持 `DISCORD_BLOCKED_GUILD_IDS` 环境变量）。
- 用户若加入了黑名单中的任意 Discord 服务器，将被禁止注册 / 登录（优先于允许规则，绑定账号也会被拦）。
- 仅在配置了黑名单时才请求 `guilds` OAuth 授权，登录前先校验。

## 后端
- 新增只读预览接口 `POST /api/channels/:id/upstream-models`；`sync-models` 现支持 `{models:[...]}` 显式选择。

## 测试
- 预览不落库、显式选择只保存所选、黑名单成员拒绝 / 非成员放行。
- `go test ./...` ✅、`npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)