### PR TITLE
fix: 创建表单『获取模型』改为清晰按钮并贴近模型框

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3368,11 +3368,7 @@ function ChannelsView({
             <div className="channel-form-wide channel-model-field">
               <div className="field-label-row">
                 <span>模型</span>
-                <small>可手动填写，或从上游拉取后多选</small>
-              </div>
-              <textarea value={models} onChange={(event) => setModels(event.target.value)} placeholder="多个模型用逗号分隔，或点『获取模型』从上游拉取" />
-              <div className="channel-model-actions">
-                <button type="button" className="secondary-button compact-button" onClick={() => {
+                <button type="button" className="model-pull-button" onClick={() => {
                   if (provider !== "codex" && !baseUrl.trim()) {
                     setMessage("请先填写 Base URL 再获取模型");
                     return;
@@ -3380,9 +3376,10 @@ function ChannelsView({
                   setMessage("");
                   setPickerOpen(true);
                 }}>
-                  获取模型
+                  从上游获取模型
                 </button>
               </div>
+              <textarea value={models} onChange={(event) => setModels(event.target.value)} placeholder="多个模型用逗号分隔，或点上方『从上游获取模型』拉取后多选" />
             </div>
           </div>
           <div className="channel-card-actions">

--- a/src/styles.css
+++ b/src/styles.css
@@ -2044,6 +2044,29 @@ button.table-row:hover {
   font-weight: 700;
 }
 
+/* Inline "pull models" action that sits on the model field's label row. */
+.field-label-row .model-pull-button {
+  min-height: 28px;
+  padding: 0 12px;
+  color: var(--blue);
+  background: color-mix(in srgb, var(--blue) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--blue) 26%, transparent);
+  border-radius: 999px;
+  font-size: 12.5px;
+  font-weight: 650;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 120ms ease, transform 100ms ease;
+}
+
+.field-label-row .model-pull-button:hover {
+  background: color-mix(in srgb, var(--blue) 16%, transparent);
+}
+
+.field-label-row .model-pull-button:active {
+  transform: scale(0.97);
+}
+
 .channel-form-wide {
   grid-column: span 2;
 }


### PR DESCRIPTION
承接 #2。修复你反馈的「获取模型隔得太远」。

## 问题
新增渠道表单里的「获取模型」是个透明的幽灵按钮，看起来像纯文字，而且单独占一行、下面又空一大段才到「创建渠道」行，显得很散。

## 修复
把它移到「模型」标签行的右侧，做成清晰的蓝色胶囊按钮「从上游获取模型」。这样：
- 动作一眼可见，不再像纯文字。
- 模型输入框直接衔接底部的创建行，不再有多余空隙。

无头 Chromium 渲染确认亮色下按钮清晰、间距紧凑。`npm run build` ✅、`go test ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)